### PR TITLE
fix file upload - consider metadata options by creating form data

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
-  "typescript.tsdk": "./node_modules/typescript/lib",
-  "editor.rulers": [
-    120
-  ]
+    "typescript.tsdk": "./node_modules/typescript/lib",
+    "editor.rulers": [
+        120
+    ],
+    "editor.tabSize": 2,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/client",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
###  Summary
fix file upload issue, now you can upload buffer stream as expected:
```
let file = fs.readFileSync('../file.png')
slackClient.files.upload({ channels, file, filename: 'file.png' })
```
as well as proposed fix in 307:
```
let file = fs.readFileSync('../file.png')
slackClient.files.upload({ channels, file: {value: file, options:{filename: 'file.png'}}, filename: 'file.png' })
```
related to 307

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
